### PR TITLE
Show remote db sync status

### DIFF
--- a/src/actions/updateSyncState.js
+++ b/src/actions/updateSyncState.js
@@ -1,3 +1,3 @@
-module.exports = function(code) {
-  return { type: 'UPDATE_SYNC_STATE', code };
+module.exports = function(status) {
+  return { type: 'UPDATE_SYNC_STATE', status };
 };

--- a/src/actions/updateSyncState.js
+++ b/src/actions/updateSyncState.js
@@ -1,0 +1,3 @@
+module.exports = function(state) {
+  return { type: 'UPDATE_SYNC_STATE', state };
+};

--- a/src/actions/updateSyncState.js
+++ b/src/actions/updateSyncState.js
@@ -1,3 +1,3 @@
-module.exports = function(state) {
-  return { type: 'UPDATE_SYNC_STATE', state };
+module.exports = function(code) {
+  return { type: 'UPDATE_SYNC_STATE', code };
 };

--- a/src/components/SyncComponent.js
+++ b/src/components/SyncComponent.js
@@ -4,6 +4,8 @@ import React from 'react';
 import FlatButton from 'material-ui/FlatButton';
 import FloatingActionButton from 'material-ui/FloatingActionButton';
 import NotificationSync from 'material-ui/svg-icons/notification/sync';
+import NotificationSyncDisabled from 'material-ui/svg-icons/notification/sync-disabled';
+import NotificationSyncProblem from 'material-ui/svg-icons/notification/sync-problem';
 import Dialog from 'material-ui/Dialog';
 import Formsy from 'formsy-react';
 import { FormsyText, FormsySelect, FormsyToggle } from 'formsy-material-ui/lib';
@@ -12,6 +14,7 @@ import Snackbar from 'material-ui/Snackbar';
 import { defineMessages, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import editSettings from '../actions/editSettings';
+import * as SyncStates from '../constants/SyncStates.js'
 
 require('styles//Sync.scss');
 
@@ -128,6 +131,18 @@ class SyncComponent extends React.Component {
     location.reload();
   }
 
+  renderSVGForSyncState() {
+    if (this.props.syncState.status === SyncStates.NOT_CONNECTED) {
+      return <NotificationSyncDisabled />
+    }
+    if (this.props.syncState.status === SyncStates.UNKNOWN_ERROR ||
+        this.props.syncState.status === SyncStates.LOGIN_FAILED ) {
+      return <NotificationSyncProblem />
+    }
+
+    return <NotificationSync />
+  }
+
   render() {
     const {formatMessage} = this.props.intl;
 
@@ -147,7 +162,7 @@ class SyncComponent extends React.Component {
           mini={true}
           onTouchTap={this.openDialogForm}
         >
-          <NotificationSync />
+          {this.renderSVGForSyncState()}
         </FloatingActionButton>
 
         <Snackbar
@@ -251,7 +266,8 @@ SyncComponent.defaultProps = {
 
 function mapStateToProps(state) {
   return {
-    settings: state.settings
+    settings: state.settings,
+    syncState: state.syncState
   };
 }
 

--- a/src/constants/SyncStates.js
+++ b/src/constants/SyncStates.js
@@ -1,0 +1,6 @@
+export const NOT_CONNECTED = 'NOT_CONNECTED'
+export const CHANGED = 'CHANGED'
+export const PAUSED = 'PAUSED'
+export const ACTIVE = 'ACTIVE'
+export const LOGIN_FAILED = 'LOGIN_FAILED'
+export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -14,8 +14,14 @@ import Main from '../components/Main';
 /* Populated by react-webpack-redux:reducer */
 class App extends Component {
   render() {
-    const {actions, slides, settings} = this.props;
-    return <Main actions={actions} slides={slides} settings={settings}/>;
+    const {actions, slides, settings, syncState} = this.props;
+    return (
+      <Main
+        actions={actions}
+        slides={slides}
+        settings={settings}
+        syncState={syncState}/>
+    );
   }
 }
 /* Populated by react-webpack-redux:reducer
@@ -26,13 +32,15 @@ class App extends Component {
 App.propTypes = {
   actions: PropTypes.object.isRequired,
   slides: PropTypes.array.isRequired,
-  settings: PropTypes.object.isRequired
+  settings: PropTypes.object.isRequired,
+  syncState: PropTypes.object.isRequired
 };
 function mapStateToProps(state) {
   /* Populated by react-webpack-redux:reducer */
   const props = {
     slides: state.slides,
-    settings: state.settings
+    settings: state.settings,
+    syncState: state.syncState
   };
   return props;
 }
@@ -42,7 +50,8 @@ function mapDispatchToProps(dispatch) {
     addSlide: require('../actions/addSlide.js'),
     deleteSlide: require('../actions/deleteSlide.js'),
     editSlide: require('../actions/editSlide.js'),
-    editSettings: require('../actions/editSettings.js')
+    editSettings: require('../actions/editSettings.js'),
+    updateSyncState: require('../actions/updateSyncState.js')
   };
   const actionMap = { actions: bindActionCreators(actions, dispatch) };
   return actionMap;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,6 +10,7 @@ import { combineReducers } from 'redux';
 /* Populated by react-webpack-redux:reducer */
 const reducers = {
   slides: require('../reducers/slides.js'),
-  settings: require('../reducers/settings.js')
+  settings: require('../reducers/settings.js'),
+  syncState: require('../reducers/syncState.js')
 };
 module.exports = combineReducers(reducers);

--- a/src/reducers/syncState.js
+++ b/src/reducers/syncState.js
@@ -1,0 +1,24 @@
+/* Define your initial state here.
+ *
+ * If you change the type from object to something else, do not forget to update
+ * src/container/App.js accordingly.
+ */
+const initialState = {};
+
+module.exports = function(state = initialState, action) {
+  /* Keep the reducer clean - do not mutate the original state. */
+  //let nextState = Object.assign({}, state);
+
+  switch(action.type) {
+    /*
+    case 'YOUR_ACTION': {
+      // Modify next state depending on the action and return it
+      return nextState;
+    } break;
+    */
+    default: {
+      /* Return original state if no actions were consumed. */
+      return state;
+    }
+  }
+}

--- a/src/reducers/syncState.js
+++ b/src/reducers/syncState.js
@@ -1,7 +1,7 @@
 import * as SyncStates from '../constants/SyncStates.js'
 
 const initialState = {
-  status: SyncStates.NOT_CONNECTED,
+  status: SyncStates.NOT_CONNECTED
 };
 
 module.exports = function(state = initialState, action) {
@@ -11,7 +11,6 @@ module.exports = function(state = initialState, action) {
     case 'UPDATE_SYNC_STATE': {
       nextState.status = action.status;
       return nextState;
-      break;
     }
     default: {
       /* Return original state if no actions were consumed. */

--- a/src/reducers/syncState.js
+++ b/src/reducers/syncState.js
@@ -1,25 +1,19 @@
-/* Define your initial state here.
- *
- * If you change the type from object to something else, do not forget to update
- * src/container/App.js accordingly.
- */
-const codeNotConnected = 0;
+// Using a proprietary HTTP status code for the not connected state
+const codeNotConnected = 900;
 
 const initialState = {
   code: codeNotConnected
 };
 
 module.exports = function(state = initialState, action) {
-  /* Keep the reducer clean - do not mutate the original state. */
-  //let nextState = Object.assign({}, state);
+  let nextState = Object.assign({}, state);
 
   switch(action.type) {
-    /*
-    case 'YOUR_ACTION': {
-      // Modify next state depending on the action and return it
+    case 'UPDATE_SYNC_STATE': {
+      nextState.code = action.code;
       return nextState;
-    } break;
-    */
+      break;
+    }
     default: {
       /* Return original state if no actions were consumed. */
       return state;

--- a/src/reducers/syncState.js
+++ b/src/reducers/syncState.js
@@ -1,8 +1,7 @@
-// Using a proprietary HTTP status code for the not connected state
-const statusNotConnected = 'NOT_CONNECTED';
+import * as SyncStates from '../constants/SyncStates.js'
 
 const initialState = {
-  status: statusNotConnected,
+  status: SyncStates.NOT_CONNECTED,
 };
 
 module.exports = function(state = initialState, action) {

--- a/src/reducers/syncState.js
+++ b/src/reducers/syncState.js
@@ -3,7 +3,11 @@
  * If you change the type from object to something else, do not forget to update
  * src/container/App.js accordingly.
  */
-const initialState = {};
+const codeNotConnected = 0;
+
+const initialState = {
+  code: codeNotConnected
+};
 
 module.exports = function(state = initialState, action) {
   /* Keep the reducer clean - do not mutate the original state. */

--- a/src/reducers/syncState.js
+++ b/src/reducers/syncState.js
@@ -1,8 +1,8 @@
 // Using a proprietary HTTP status code for the not connected state
-const codeNotConnected = 900;
+const statusNotConnected = 'NOT_CONNECTED';
 
 const initialState = {
-  code: codeNotConnected
+  status: statusNotConnected,
 };
 
 module.exports = function(state = initialState, action) {
@@ -10,7 +10,7 @@ module.exports = function(state = initialState, action) {
 
   switch(action.type) {
     case 'UPDATE_SYNC_STATE': {
-      nextState.code = action.code;
+      nextState.status = action.status;
       return nextState;
       break;
     }

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -62,33 +62,32 @@ module.exports = function(initialState) {
       remoteDbSettings = remoteDbSettingsFromUrl;
     }
 
-    const remoteDb = new PouchDB(remoteDbSettings.remoteDbUrl, {skipSetup: true});
-    // Clearing a previously created session
-    remoteDb.logout();
-
-    //var db = new PouchDB('http://localhost:5984/mydb', {skipSetup: true});
-    // Trying to authenticate against the remote database if necessary
-    if (typeof remoteDbSettings.remoteDbUser !== 'undefined' &&
-        typeof remoteDbSettings.remoteDbPassword !== 'undefined' ) {
-      remoteDb.login(remoteDbSettings.remoteDbUser, remoteDbSettings.remoteDbPassword, function (err, response) {
-        if (err) {
-          if (err.name === 'unauthorized') {
-            // name or password incorrect
-          } else {
-            // cosmic rays, a meteor, etc.
-          }
-        }
-      });
-    }
-
     if (remoteDbSettings.enabled) {
+      const remoteDb = new PouchDB(remoteDbSettings.remoteDbUrl, {skipSetup: true});
+      // Clearing a previously created session
+      remoteDb.logout();
+
+      //var db = new PouchDB('http://localhost:5984/mydb', {skipSetup: true});
+      // Trying to authenticate against the remote database if necessary
+      if (typeof remoteDbSettings.remoteDbUser !== 'undefined' &&
+        typeof remoteDbSettings.remoteDbPassword !== 'undefined' ) {
+        remoteDb.login(remoteDbSettings.remoteDbUser, remoteDbSettings.remoteDbPassword, function (err, response) {
+          if (err) {
+            if (err.name === 'unauthorized') {
+              // name or password incorrect
+            } else {
+              // cosmic rays, a meteor, etc.
+            }
+          }
+        });
+      }
+
       switch (remoteDbSettings.syncMode) {
         case 1:
           db.replicate.from(remoteDb, {
             live: true,
             retry: true
           })
-          /*
             .on('change', function (change) {
             console.log('yo, something changed!');
           }).on('paused', function (info) {
@@ -97,16 +96,13 @@ module.exports = function(initialState) {
             console.log('replication was resumed');
           }).on('error', function (err) {
             console.log('totally unhandled error (shouldn\'t happen)');
-          })
-          */
-          ;
+          });
           break;
         case 2:
           db.replicate.to(remoteDb, {
             live: true,
             retry: true
           })
-          /*
             .on('change', function (change) {
             console.log('yo, something changed!');
           }).on('paused', function (info) {
@@ -115,16 +111,13 @@ module.exports = function(initialState) {
             console.log('replication was resumed');
           }).on('error', function (err) {
             console.log('totally unhandled error (shouldn\'t happen)');
-          })
-          */
-          ;
+          });
           break;
         case 3:
           db.sync(remoteDb, {
             live: true,
             retry: true
           })
-          /*
           .on('change', function (change) {
             console.log('yo, something changed!');
           }).on('paused', function (info) {
@@ -133,9 +126,7 @@ module.exports = function(initialState) {
             console.log('replication was resumed');
           }).on('error', function (err) {
             console.log('totally unhandled error (shouldn\'t happen)');
-          })
-          */
-          ;
+          });
           break;
       }
     }

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -65,13 +65,15 @@ module.exports = function(initialState) {
 
     if (remoteDbSettings.enabled) {
       const remoteDb = new PouchDB(remoteDbSettings.remoteDbUrl, {skipSetup: true});
-      // Clearing a previously created session
-      remoteDb.logout();
 
       //var db = new PouchDB('http://localhost:5984/mydb', {skipSetup: true});
       // Trying to authenticate against the remote database if necessary
       if (typeof remoteDbSettings.remoteDbUser !== 'undefined' &&
         typeof remoteDbSettings.remoteDbPassword !== 'undefined' ) {
+
+        // Clearing a previously created session
+        remoteDb.logout();
+
         remoteDb.login(remoteDbSettings.remoteDbUser, remoteDbSettings.remoteDbPassword, function (err, response) {
           if (err) {
             if (err.name === 'unauthorized') {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -7,6 +7,7 @@ import PouchMiddleware from 'pouch-redux-middleware'
 import PouchDB from 'pouchdb';
 import PouchDBAuthentication from 'pouchdb-authentication';
 PouchDB.plugin(PouchDBAuthentication);
+import updateSyncStateAction from '../actions/updateSyncState.js'
 
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
@@ -118,13 +119,17 @@ module.exports = function(initialState) {
             live: true,
             retry: true
           })
-          .on('change', function (change) {
+          .on('change', function () {
+            store.dispatch(updateSyncStateAction('CHANGE'));
             console.log('yo, something changed!');
-          }).on('paused', function (info) {
+          }).on('paused', function () {
+            store.dispatch(updateSyncStateAction('PAUSED'));
             console.log('replication was paused, usually because of a lost connection');
-          }).on('active', function (info) {
+          }).on('active', function () {
+            store.dispatch(updateSyncStateAction('ACTIVE'));
             console.log('replication was resumed');
-          }).on('error', function (err) {
+          }).on('error', function () {
+            store.dispatch(updateSyncStateAction('ERROR'));
             console.log('totally unhandled error (shouldn\'t happen)');
           });
           break;

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -76,10 +76,12 @@ module.exports = function(initialState) {
 
         remoteDb.login(remoteDbSettings.remoteDbUser, remoteDbSettings.remoteDbPassword, function (err, response) {
           if (err) {
-            if (err.name === 'unauthorized') {
-              // name or password incorrect
+            if (err.status === 400 || err.status === 401) {
+              // 400: Name or password are missing
+              // 401: Name or password are incorrect
+              store.dispatch(updateSyncStateAction('LOGIN_FAILED'))
             } else {
-              // cosmic rays, a meteor, etc.
+              store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'))
             }
           }
         });
@@ -91,14 +93,14 @@ module.exports = function(initialState) {
             live: true,
             retry: true
           })
-            .on('change', function (change) {
-            console.log('yo, something changed!');
-          }).on('paused', function (info) {
-            console.log('replication was paused, usually because of a lost connection');
-          }).on('active', function (info) {
-            console.log('replication was resumed');
-          }).on('error', function (err) {
-            console.log('totally unhandled error (shouldn\'t happen)');
+          .on('change', function () {
+            store.dispatch(updateSyncStateAction('CHANGE'));
+          }).on('paused', function () {
+            store.dispatch(updateSyncStateAction('PAUSED'));
+          }).on('active', function () {
+            store.dispatch(updateSyncStateAction('ACTIVE'));
+          }).on('error', function () {
+            store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'));
           });
           break;
         case 2:
@@ -106,14 +108,14 @@ module.exports = function(initialState) {
             live: true,
             retry: true
           })
-            .on('change', function (change) {
-            console.log('yo, something changed!');
-          }).on('paused', function (info) {
-            console.log('replication was paused, usually because of a lost connection');
-          }).on('active', function (info) {
-            console.log('replication was resumed');
-          }).on('error', function (err) {
-            console.log('totally unhandled error (shouldn\'t happen)');
+          .on('change', function () {
+            store.dispatch(updateSyncStateAction('CHANGE'));
+          }).on('paused', function () {
+            store.dispatch(updateSyncStateAction('PAUSED'));
+          }).on('active', function () {
+            store.dispatch(updateSyncStateAction('ACTIVE'));
+          }).on('error', function () {
+            store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'));
           });
           break;
         case 3:
@@ -123,16 +125,12 @@ module.exports = function(initialState) {
           })
           .on('change', function () {
             store.dispatch(updateSyncStateAction('CHANGE'));
-            console.log('yo, something changed!');
           }).on('paused', function () {
             store.dispatch(updateSyncStateAction('PAUSED'));
-            console.log('replication was paused, usually because of a lost connection');
           }).on('active', function () {
             store.dispatch(updateSyncStateAction('ACTIVE'));
-            console.log('replication was resumed');
           }).on('error', function () {
-            store.dispatch(updateSyncStateAction('ERROR'));
-            console.log('totally unhandled error (shouldn\'t happen)');
+            store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'));
           });
           break;
       }

--- a/test/actions/ActionsTest.js
+++ b/test/actions/ActionsTest.js
@@ -2,6 +2,7 @@ import addSlideAction from 'actions//addSlide.js'
 import deleteSlideAction from 'actions//deleteSlide.js'
 import editSlideAction from 'actions//editSlide.js'
 import editSettingsAction from 'actions//editSettings.js'
+import updateSyncStateAction from 'actions//updateSyncState.js'
 
 describe('Actions', () => {
   it('should create an action to add a slide', () => {
@@ -54,5 +55,14 @@ describe('Actions', () => {
       settings: settings
     }
     expect(editSettingsAction(settings)).to.deep.equal(expectedAction)
+  })
+
+  it('should create an action to update the state of the sync with a remote db', () => {
+    const code = 'somecode';
+    const expectedAction = {
+      type: 'UPDATE_SYNC_STATE',
+      code: code
+    }
+    expect(updateSyncStateAction(code)).to.deep.equal(expectedAction)
   })
 })

--- a/test/actions/ActionsTest.js
+++ b/test/actions/ActionsTest.js
@@ -58,11 +58,11 @@ describe('Actions', () => {
   })
 
   it('should create an action to update the state of the sync with a remote db', () => {
-    const code = 'somecode';
+    const status = 'somestatus';
     const expectedAction = {
       type: 'UPDATE_SYNC_STATE',
-      code: code
+      status: status
     }
-    expect(updateSyncStateAction(code)).to.deep.equal(expectedAction)
+    expect(updateSyncStateAction(status)).to.deep.equal(expectedAction)
   })
 })

--- a/test/reducers/syncStateTest.js
+++ b/test/reducers/syncStateTest.js
@@ -16,4 +16,30 @@ describe('syncState', () => {
 
     done();
   });
+
+  it('should handle EDIT_SETTINGS when there is no change', () => {
+    expect(
+      reducer({status: SyncStates.NOT_CONNECTED},
+        {
+          type: 'UPDATE_SYNC_STATE',
+          status: SyncStates.NOT_CONNECTED
+        }
+      )
+    ).to.deep.equal({status: SyncStates.NOT_CONNECTED})
+  })
+
+  it('should handle EDIT_SETTINGS when there is a change', () => {
+    expect(
+      reducer({status: SyncStates.NOT_CONNECTED},
+        {
+          type: 'UPDATE_SYNC_STATE',
+          status: SyncStates.ACTIVE
+        }
+      )
+    ).to.deep.equal(
+      {
+        status: SyncStates.ACTIVE
+      }
+    )
+  })
 });

--- a/test/reducers/syncStateTest.js
+++ b/test/reducers/syncStateTest.js
@@ -1,0 +1,12 @@
+var reducer = require('../../src/reducers/syncState');
+
+describe('syncState', () => {
+
+  it('should not change the passed state', (done) => {
+
+    const state = Object.freeze({});
+    reducer(state, {type: 'INVALID'});
+
+    done();
+  });
+});

--- a/test/reducers/syncStateTest.js
+++ b/test/reducers/syncStateTest.js
@@ -1,11 +1,12 @@
 var reducer = require('../../src/reducers/syncState');
+import * as SyncStates from '../../src/constants/SyncStates.js'
 
 describe('syncState', () => {
 
   it('should return the initial state', () => {
     expect(
       reducer(undefined, {})
-    ).to.deep.equal({code: 900})
+    ).to.deep.equal({status: SyncStates.NOT_CONNECTED})
   })
 
   it('should not change the passed state', (done) => {

--- a/test/reducers/syncStateTest.js
+++ b/test/reducers/syncStateTest.js
@@ -2,6 +2,12 @@ var reducer = require('../../src/reducers/syncState');
 
 describe('syncState', () => {
 
+  it('should return the initial state', () => {
+    expect(
+      reducer(undefined, {})
+    ).to.deep.equal({code: 0})
+  })
+
   it('should not change the passed state', (done) => {
 
     const state = Object.freeze({});

--- a/test/reducers/syncStateTest.js
+++ b/test/reducers/syncStateTest.js
@@ -5,7 +5,7 @@ describe('syncState', () => {
   it('should return the initial state', () => {
     expect(
       reducer(undefined, {})
-    ).to.deep.equal({code: 0})
+    ).to.deep.equal({code: 900})
   })
 
   it('should not change the passed state', (done) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The svg icon for the sync settings is changing in regard of the current sync state

## Description
<!--- Describe your changes in detail -->
If there is a problem with the sync only a tech savvy user is able get a clue about it by paying attention to console. This pull request will add an indication of the state of the sync by changing the appearance of the fab for the sync settings. It will show either an icon for a disabled, properly enabled or wrongly configured sync. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #127 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
see above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes it has been tested and is partially covered by unit tests
- Reducer and action is covered by 100%
- Component test needs to be refactored to use enzyme and to work with the HOCs

## Screenshots (if appropriate):
n.a.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- This projects uses SemVer http://semver.org -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

<!-- Regarding tests and coding styles - just relax this project has an automated tests setup. However if you want to run tests locally, than you can use ```npm run test``` from the command line. Pull requests won't be accepted if the automated travis build process failed. Should overall test coverage sink significantly the pull request won't be accepted as well as long as you do not provide more tests ;-) -->
