### PR TITLE
Refactors the code in favor of using the sync constants instead of st…

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -8,6 +8,7 @@ import PouchDB from 'pouchdb';
 import PouchDBAuthentication from 'pouchdb-authentication';
 PouchDB.plugin(PouchDBAuthentication);
 import updateSyncStateAction from '../actions/updateSyncState.js'
+import * as SyncStates from '../constants/SyncStates.js'
 
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
@@ -79,9 +80,9 @@ module.exports = function(initialState) {
             if (err.status === 400 || err.status === 401) {
               // 400: Name or password are missing
               // 401: Name or password are incorrect
-              store.dispatch(updateSyncStateAction('LOGIN_FAILED'))
+              store.dispatch(updateSyncStateAction(SyncStates.LOGIN_FAILED))
             } else {
-              store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'))
+              store.dispatch(updateSyncStateAction(SyncStates.UNKNOWN_ERROR))
             }
           }
         });
@@ -94,13 +95,13 @@ module.exports = function(initialState) {
             retry: true
           })
           .on('change', function () {
-            store.dispatch(updateSyncStateAction('CHANGE'));
+            store.dispatch(updateSyncStateAction(SyncStates.CHANGE));
           }).on('paused', function () {
-            store.dispatch(updateSyncStateAction('PAUSED'));
+            store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
           }).on('active', function () {
-            store.dispatch(updateSyncStateAction('ACTIVE'));
+            store.dispatch(updateSyncStateAction(SyncStates.ACTIVE));
           }).on('error', function () {
-            store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'));
+            store.dispatch(updateSyncStateAction(SyncStates.UNKNOWN_ERROR));
           });
           break;
         case 2:
@@ -109,13 +110,13 @@ module.exports = function(initialState) {
             retry: true
           })
           .on('change', function () {
-            store.dispatch(updateSyncStateAction('CHANGE'));
+            store.dispatch(updateSyncStateAction(SyncStates.CHANGE));
           }).on('paused', function () {
-            store.dispatch(updateSyncStateAction('PAUSED'));
+            store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
           }).on('active', function () {
-            store.dispatch(updateSyncStateAction('ACTIVE'));
+            store.dispatch(updateSyncStateAction(SyncStates.ACTIVE));
           }).on('error', function () {
-            store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'));
+            store.dispatch(updateSyncStateAction(SyncStates.UNKNOWN_ERROR));
           });
           break;
         case 3:
@@ -124,13 +125,13 @@ module.exports = function(initialState) {
             retry: true
           })
           .on('change', function () {
-            store.dispatch(updateSyncStateAction('CHANGE'));
+            store.dispatch(updateSyncStateAction(SyncStates.CHANGE));
           }).on('paused', function () {
-            store.dispatch(updateSyncStateAction('PAUSED'));
+            store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
           }).on('active', function () {
-            store.dispatch(updateSyncStateAction('ACTIVE'));
+            store.dispatch(updateSyncStateAction(SyncStates.ACTIVE));
           }).on('error', function () {
-            store.dispatch(updateSyncStateAction('UNKNOWN_ERROR'));
+            store.dispatch(updateSyncStateAction(SyncStates.UNKNOWN_ERROR));
           });
           break;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactors the code in favor of using the sync constants instead of magic strings

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #136 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Raise maintainability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):
n.a.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- This projects uses SemVer http://semver.org -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

<!-- Regarding tests and coding styles - just relax this project has an automated tests setup. However if you want to run tests locally, than you can use ```npm run test``` from the command line. Pull requests won't be accepted if the automated travis build process failed. Should overall test coverage sink significantly the pull request won't be accepted as well as long as you do not provide more tests ;-) -->

…ring literals