### PR TITLE
Deactivates the propagation of the PUASED state as it can be error prone

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -95,7 +95,7 @@ module.exports = function(initialState) {
           .on('change', function () {
             store.dispatch(updateSyncStateAction(SyncStates.CHANGE));
           }).on('paused', function () {
-            store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
+            //store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
           }).on('active', function () {
             store.dispatch(updateSyncStateAction(SyncStates.ACTIVE));
           }).on('error', function () {
@@ -110,7 +110,7 @@ module.exports = function(initialState) {
           .on('change', function () {
             store.dispatch(updateSyncStateAction(SyncStates.CHANGE));
           }).on('paused', function () {
-            store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
+            //store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
           }).on('active', function () {
             store.dispatch(updateSyncStateAction(SyncStates.ACTIVE));
           }).on('error', function () {
@@ -125,7 +125,7 @@ module.exports = function(initialState) {
           .on('change', function () {
             store.dispatch(updateSyncStateAction(SyncStates.CHANGE));
           }).on('paused', function () {
-            store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
+            //store.dispatch(updateSyncStateAction(SyncStates.PAUSED));
           }).on('active', function () {
             store.dispatch(updateSyncStateAction(SyncStates.ACTIVE));
           }).on('error', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #141 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- This projects uses SemVer http://semver.org -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

<!-- Regarding tests and coding styles - just relax this project has an automated tests setup. However if you want to run tests locally, than you can use ```npm run test``` from the command line. Pull requests won't be accepted if the automated travis build process failed. Should overall test coverage sink significantly the pull request won't be accepted as well as long as you do not provide more tests ;-) -->

If a remote couch db connection refuses the connection the live sync will fall back to PAUSED and thus indicate that the connection is properly setup within the SyncState component. PAUSED however is decent as an active indicator when the previous state has been ACTIVE or CHANGED